### PR TITLE
Fix mob preview not loading for consolidated Mob.img structure (Base.wz)

### DIFF
--- a/WzComparerR2.Common/CharaSim/Mob.cs
+++ b/WzComparerR2.Common/CharaSim/Mob.cs
@@ -93,7 +93,7 @@ namespace WzComparerR2.CharaSim
         public static Mob CreateFromNode(Wz_Node node, GlobalFindNodeFunction findNode)
         {
             int mobID;
-            Match m = Regex.Match(node.Text, @"^(\d{7})\.img$");
+            Match m = Regex.Match(node.Text, @"^(\d{7})(?:\.img)?$");
             if (!(m.Success && Int32.TryParse(m.Result("$1"), out mobID)))
             {
                 return null;

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -3450,9 +3450,18 @@ namespace WzComparerR2
 
                 case Wz_Type.Mob:
                     if (selectedNode.FullPathToFile.Contains("BossPattern")) return; // Ignore BossPattern to prevent Auto Preview crash
-                    if ((image = selectedNode.GetValue<Wz_Image>()) == null || !image.TryExtract())
-                        return;
-                    var mob = Mob.CreateFromNode(image.Node, PluginManager.FindWz);
+                    Wz_Node mobNode;
+                    if ((image = selectedNode.GetValue<Wz_Image>()) != null)
+                    {
+                        if (!image.TryExtract()) return;
+                        mobNode = image.Node;
+                    }
+                    else
+                    {
+                        // JMS structure: node is a mob ID inside a consolidated Mob.img
+                        mobNode = selectedNode;
+                    }
+                    var mob = Mob.CreateFromNode(mobNode, PluginManager.FindWz);
                     obj = mob;
                     if (stringLinker == null || !stringLinker.StringMob.TryGetValue(mob.ID, out sr))
                     {


### PR DESCRIPTION
Hi! I wanted to reference how boss HP is handled, but I couldn't find it, so I put this together based on my best guess.
I didn't have an environment to verify it, so I apologize if the implementationis rough. Please take a look whenever you have time — no rush at all!

 ## Summary

  - In JMS `Base.wz`, mob data is stored as nodes inside a single `Mob.img` (e.g. `Mob\Mob.img\9210070`) rather than individual `{id}.img` files
  - The `Wz_Type.Mob` case in `quickView` returned early because `selectedNode.GetValue<Wz_Image>()` returned `null` for nodes inside a consolidated `Mob.img`
  - The regex in `Mob.CreateFromNode` required the `.img` suffix, so node names like `9210070` did not match

  ## Changes

  - `Mob.CreateFromNode`: relaxed regex to `^(\d{7})(?:\.img)?$` to also match node names without the `.img` suffix
  - `MainForm.quickView`: in the `Wz_Type.Mob` case, fall through to `Mob.CreateFromNode` with the selected node directly when it is not a `Wz_Image` (i.e. a mob ID node inside a consolidated `Mob.img`)